### PR TITLE
Fix bug in MMVP pair accuracy calculation by removing data shuffle

### DIFF
--- a/eval/eval_mmvp.py
+++ b/eval/eval_mmvp.py
@@ -108,9 +108,6 @@ if __name__ == "__main__":
         data[i]['pair_index'] = i//2
         data[i+1]['pair_index'] = i//2
 
-    random.seed(42)
-    random.shuffle(data)
-
     # Split data for distributed evaluation
     per_rank_data = len(data) // world_size
     start_idx = rank * per_rank_data


### PR DESCRIPTION
- `random.shuffle(data)` breaks the adjacency assumption used in pair accuracy calculation (line 209), causing unrelated questions to be paired together
- Removed the shuffle so that original CSV pair ordering is preserved

### Evaluation Results
| Model | Paper | My result before fix | My result after fix  |
|-------|-----|-----------|----------|
| Qwen2.5-VL-7B-Instruct | 54.66 | 54.66 | 50.00 |
| visual_jigsaw_image_7B | 60.66 | 60.00 | 57.33 |

